### PR TITLE
Add initial web landing page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.next
+dist
+build
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ locker-app/
 
 ## Notes for Future Contributors
 - This repository currently contains only planning documentation; application code will be added in future milestones.
+- For every pull request, append a timestamped summary of changes to `worklog.txt`.
 - Keep code well‑commented and prefer readability over cleverness.
 - Avoid obscure libraries; favor those with abundant documentation and active communities.
 - Document any architectural decisions in `/docs/architecture.md` as the project evolves.

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Locker App</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <main class="hero">
+    <h1>Locker App</h1>
+    <p>Autonomous e-bike rentals in Sedona, Arizona. Coming soon.</p>
+  </main>
+</body>
+</html>

--- a/apps/web/styles.css
+++ b/apps/web/styles.css
@@ -1,0 +1,14 @@
+body {
+  margin: 0;
+  padding: 0;
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  background: #f5f5f5;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.hero {
+  text-align: center;
+}

--- a/worklog.txt
+++ b/worklog.txt
@@ -1,0 +1,18 @@
+## Work Log
+
+### 2025-08-11 03:22:02 UTC
+- Read README.md to understand the planned project architecture and directory layout.
+- Created base folder structure as specified in the README:
+  - apps/ with web/, mobile/, api/ subdirectories.
+  - packages/ with ui/ and lib/ subdirectories.
+  - infrastructure/ with docker/ and iot/ subdirectories.
+- Added .gitkeep files to each directory to ensure they are tracked by Git.
+
+### 2025-08-11 03:22:50 UTC
+- Updated README with instructions to add a timestamped work-log entry for every pull request.
+- Added timestamps to existing work log entries.
+
+### 2025-08-11 03:30:40 UTC
+- Attempted to initialize Next.js app for the web frontend but installation failed due to a 403 error fetching packages.
+- Created a simple static landing page under apps/web with basic styling as a starting point.
+- Added a root .gitignore to keep node_modules and build artifacts out of version control.


### PR DESCRIPTION
## Summary
- add root `.gitignore` for node and build artifacts
- scaffold simple static landing page in `apps/web`
- log landing page work in timestamped work log

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689960d9e6b483279db947dd023bc0c1